### PR TITLE
fix(contracts): export TypeScript source instead of missing dist for …

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/index.js",
+      "require": "./src/index.ts",
+      "import": "./src/index.ts",
       "types": "./src/index.ts"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./src/index.ts",
   "scripts": {
     "build": "tsc",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
…Bun compatibility

The contracts package exported ./dist/index.js which was never built, causing Bun to fail when resolving @portfolio/contracts in the mcp-server. Since the monorepo runs TypeScript natively via Bun/tsx/Angular, pointing exports to ./src/index.ts avoids the need for a pre-built dist.