### PR TITLE
fix(api): use includeFiles instead of invalid outputFileTracingRoot

### DIFF
--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -1,7 +1,11 @@
 {
   "framework": null,
   "outputDirectory": ".",
-  "outputFileTracingRoot": "../../",
+  "functions": {
+    "api/index.ts": {
+      "includeFiles": "node_modules/@portfolio/contracts/dist/**"
+    }
+  },
   "rewrites": [
     { "source": "/(.*)", "destination": "/api" }
   ],


### PR DESCRIPTION
outputFileTracingRoot is a Next.js option, not a valid vercel.json property. Use functions.includeFiles to explicitly bundle contracts/dist into the Lambda, bypassing pnpm symlink resolution issues in Vercel's nft bundler.